### PR TITLE
Check for null objects

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -95,31 +95,31 @@ post_class: post-template
             </p>
 
             <!-- Post Categories -->
-            {% if page.catgories != nil %}
-<div class="after-post-cats">
-    <ul class="tags mb-4">
-        {% assign sortedCategories = page.categories | sort %}
-        {% for category in sortedCategories %}
-        <li>
-            <a class="smoothscroll" href="{{site.baseurl}}/categories#{{ category | replace: " ","-" }}">{{ category }}</a>
-        </li>
-        {% endfor %}
-    </ul>
-</div>
-{% endif %}
+            {% if page.catgories %}
+            <div class="after-post-cats">
+                <ul class="tags mb-4">
+                    {% assign sortedCategories = page.categories | sort %}
+                    {% for category in sortedCategories %}
+                    <li>
+                        <a class="smoothscroll" href="{{site.baseurl}}/categories#{{ category | replace: " ","-" }}">{{ category }}</a>
+                    </li>
+                    {% endfor %}
+                </ul>
+            </div>
+            {% endif %}
 
-{% if page.tags != nil %}
-<div class="after-post-tags">
-    <ul class="tags">
-        {% assign sortedTags = page.tags | sort %}
-        {% for tag in sortedTags %}
-        <li>
-            <a class="smoothscroll" href="{{site.baseurl}}/tags#{{ tag | replace: " ","-" }}">#{{ tag }}</a>
-        </li>
-        {% endfor %}
-    </ul>
-</div>
-{% endif %}
+            {% if page.tags %}
+            <div class="after-post-tags">
+                <ul class="tags">
+                    {% assign sortedTags = page.tags | sort %}
+                    {% for tag in sortedTags %}
+                    <li>
+                        <a class="smoothscroll" href="{{site.baseurl}}/tags#{{ tag | replace: " ","-" }}">#{{ tag }}</a>
+                    </li>
+                    {% endfor %}
+                </ul>
+            </div>
+            {% endif %}
             <!-- <div class="after-post-cats">
                 <ul class="tags mb-4">
                     {% assign sortedCategories = page.categories | sort %}


### PR DESCRIPTION
Check for null objects before posts and categories are displayed according to the post layout. 

This fixes the build even if not all posts have categories and tags defined in the front matter.